### PR TITLE
인증 서비스 초기 버전

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -15,7 +15,20 @@ repositories {
 
 dependencies {
     implementation(project(":common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.auth0:java-jwt:3.18.2")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    runtimeOnly("com.h2database:h2")
     testImplementation(kotlin("test"))
+    testImplementation("io.mockk:mockk:1.13.4")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")
+    testRuntimeOnly("com.h2database:h2")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 }
 
 tasks.test {

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/Application.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/Application.kt
@@ -2,8 +2,10 @@ package kr.dohoon_kim.msa.auth_service
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class Application {
 }
 

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/codes/ServiceErrorCode.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/codes/ServiceErrorCode.kt
@@ -1,0 +1,8 @@
+package kr.dohoon_kim.msa.auth_service.codes
+
+enum class ServiceErrorCode(val code: String){
+
+    AUTHENTICATION_INFO_NOT_FOUND("AUTH-ERROR-0001"),
+    AUTHENTICATION_INFO_NOT_MATCH("AUTH-ERROR-0002"),
+    JWT_VERIFICATION_FAILED("AUTH-ERROR-0003")
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/configs/JwtConfiguration.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/configs/JwtConfiguration.kt
@@ -1,0 +1,20 @@
+package kr.dohoon_kim.msa.auth_service.configs
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JwtConfiguration(
+    @Value("\${jwt.access-token.secret}")
+    val accessTokenSecret: String,
+    @Value("\${jwt.refresh-token.secret}")
+    val refreshTokenSecret: String,
+    @Value("\${jwt.access-token.expiration}")
+    val accessTokenExpiration: Long,
+    @Value("\${jwt.refresh-token.expiration}")
+    val refreshTokenExpiration: Long,
+    @Value("\${jwt.issuer}")
+    val issuer: String
+) {
+
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/configs/SecurityConfiguration.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/configs/SecurityConfiguration.kt
@@ -1,0 +1,42 @@
+package kr.dohoon_kim.msa.auth_service.configs
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.web.filter.CorsFilter
+
+@Configuration
+class SecurityConfiguration {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = ["spring.h2.console.enabled"],havingValue = "true")
+    fun ignoringWebSecurityCustomizer(): WebSecurityCustomizer {
+        return WebSecurityCustomizer {
+            it.ignoring().requestMatchers(PathRequest.toH2Console())
+        }
+    }
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.sessionManagement { sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .cors{cors -> cors.disable()}
+            .csrf{csrf -> csrf.disable()}
+            .formLogin{formLogin -> formLogin.disable()}
+            .httpBasic{httpBasic -> httpBasic.disable()}
+            .logout{logout -> logout.disable()}
+            .authorizeHttpRequests { authorizeHttpRequests -> authorizeHttpRequests.anyRequest().permitAll() }
+        return http.build()
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/BaseEntity.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/BaseEntity.kt
@@ -1,0 +1,30 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+
+@MappedSuperclass
+@EntityListeners(value = [AuditingEntityListener::class])
+abstract class BaseEntity<T>(
+    @Id
+    private val id: T? = null
+): BaseTimeEntity() {
+
+    val identifier: T
+        get() = id!!
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BaseEntity<*>
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/BaseTimeEntity.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/BaseTimeEntity.kt
@@ -1,0 +1,15 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+
+@MappedSuperclass
+@EntityListeners(value = [AuditingEntityListener::class])
+open class BaseTimeEntity {
+
+    @CreatedDate
+    var createdAt: Instant = Instant.now()
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationInfo.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationInfo.kt
@@ -1,0 +1,30 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import com.fasterxml.jackson.databind.ser.Serializers.Base
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import java.util.UUID
+
+@Entity
+class MemberAuthenticationInfo(
+    id: MemberId? = null,
+    nickname: String = "",
+    password: String = ""
+): BaseEntity<MemberId>(id) {
+
+    @Column
+    var nickname: String = nickname
+        private set
+
+    @Column
+    var password: String = password
+        private set
+
+    fun changeNickname(nickname: String) {
+        this.nickname = nickname
+    }
+
+    fun changePassword(password: String) {
+        this.password = password
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationInfoRepository.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationInfoRepository.kt
@@ -1,0 +1,10 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MemberAuthenticationInfoRepository: JpaRepository<MemberAuthenticationInfo, MemberId> {
+
+    fun findByNickname(nickname: String): MemberAuthenticationInfo?
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberId.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberId.kt
@@ -1,0 +1,11 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import jakarta.persistence.Embeddable
+import java.util.UUID
+
+@Embeddable
+data class MemberId(
+    val id: UUID
+) {
+    constructor(): this(UUID.randomUUID())
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/AuthenticationController.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/AuthenticationController.kt
@@ -1,0 +1,35 @@
+package kr.dohoon_kim.msa.auth_service.interfaces
+
+import jakarta.validation.Valid
+import kr.dohoon_kim.lectures.msa.common.responses.Envelop
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.AuthenticationResponse
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.LoginRequest
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.NicknamePasswordLoginRequest
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.RefreshTokenRequest
+import kr.dohoon_kim.msa.auth_service.service.AuthenticationService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthenticationController(
+    private val authenticationService: AuthenticationService
+) {
+
+    @PostMapping("/nickname-password")
+    @Envelop(status = HttpStatus.CREATED, message = "로그인 성공")
+    fun login(@RequestBody @Valid request: NicknamePasswordLoginRequest): AuthenticationResponse {
+        return AuthenticationResponse.of(authenticationService.nicknamePasswordAuthentication(request.nickname, request.password))
+    }
+
+    @PostMapping("/jwt/refresh-token")
+    @Envelop(status = HttpStatus.CREATED, message = "토큰 재발급 성공")
+    fun refresh(@RequestBody @Valid request: RefreshTokenRequest):AuthenticationResponse {
+        return AuthenticationResponse.of(
+            authenticationService.refreshAccessToken(request.refreshToken)
+        )
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/AuthenticationResponse.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/AuthenticationResponse.kt
@@ -1,0 +1,21 @@
+package kr.dohoon_kim.msa.auth_service.interfaces.dto
+
+import kr.dohoon_kim.msa.auth_service.service.dto.AuthenticationSuccess
+
+data class AuthenticationResponse(
+    val tokenType: String,
+    val accessToken: String,
+    val refreshToken: String
+) {
+
+    companion object {
+
+        fun of(result: AuthenticationSuccess): AuthenticationResponse {
+            return AuthenticationResponse(
+                tokenType = result.type,
+                accessToken = result.accessToken,
+                refreshToken = result.refreshToken
+            )
+        }
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/LoginRequest.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/LoginRequest.kt
@@ -1,0 +1,7 @@
+package kr.dohoon_kim.msa.auth_service.interfaces.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+interface LoginRequest {
+    val principal: String
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/NicknamePasswordLoginRequest.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/NicknamePasswordLoginRequest.kt
@@ -1,0 +1,13 @@
+package kr.dohoon_kim.msa.auth_service.interfaces.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import jakarta.validation.constraints.NotEmpty
+
+class NicknamePasswordLoginRequest(
+    @field: NotEmpty(message = "닉네임은 필수입니다.")
+    val nickname: String,
+    @field: NotEmpty(message = "패스워드는 필수입니다.")
+    val password: String
+) {
+
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/RefreshTokenRequest.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/RefreshTokenRequest.kt
@@ -1,0 +1,12 @@
+package kr.dohoon_kim.msa.auth_service.interfaces.dto
+
+import jakarta.validation.constraints.NotEmpty
+
+
+data class RefreshTokenRequest(
+    val type: String = "Bearer",
+    @field: NotEmpty(message = "Refresh token must not be empty")
+    val refreshToken: String
+) {
+
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/AuthenticationService.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/AuthenticationService.kt
@@ -1,0 +1,55 @@
+package kr.dohoon_kim.msa.auth_service.service
+
+import com.auth0.jwt.exceptions.JWTVerificationException
+import kr.dohoon_kim.lectures.msa.common.responses.errors.NotFoundException
+import kr.dohoon_kim.lectures.msa.common.responses.errors.UnauthorizedException
+import kr.dohoon_kim.msa.auth_service.codes.ServiceErrorCode
+import kr.dohoon_kim.msa.auth_service.domain.MemberAuthenticationInfo
+import kr.dohoon_kim.msa.auth_service.domain.MemberAuthenticationInfoRepository
+import kr.dohoon_kim.msa.auth_service.domain.MemberId
+import kr.dohoon_kim.msa.auth_service.service.dto.AuthenticationSuccess
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+
+@Service
+class AuthenticationService(
+    private val memberAuthenticationInfoRepository: MemberAuthenticationInfoRepository,
+    private val jwtService: JWTService,
+    private val passwordEncoder: PasswordEncoder
+) {
+
+    @Transactional(readOnly = true)
+    fun nicknamePasswordAuthentication(nickname: String, password: String): AuthenticationSuccess {
+        val memberAuthenticationInfo = memberAuthenticationInfoRepository.findByNickname(nickname)
+            ?: throw UnauthorizedException(ServiceErrorCode.AUTHENTICATION_INFO_NOT_FOUND.code, "회원의 인증 정보가 존재하지 않습니다.")
+
+        return if (passwordEncoder.matches(password, memberAuthenticationInfo.password)) {
+            val accessToken = jwtService.createAccessToken(memberAuthenticationInfo.identifier)
+            val refreshToken = jwtService.createRefreshToken(memberAuthenticationInfo.identifier)
+            AuthenticationSuccess(accessToken = accessToken, refreshToken = refreshToken)
+        } else {
+            throw UnauthorizedException(ServiceErrorCode.AUTHENTICATION_INFO_NOT_FOUND.code, "회원의 인증 정보가 일치하지 않습니다.")
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun refreshAccessToken(refreshToken: String): AuthenticationSuccess {
+        var memberId: MemberId = MemberId(UUID.randomUUID())
+
+        try {
+            val decodedRefreshToken = jwtService.verifyRefreshToken(refreshToken)
+            memberId = MemberId(UUID.fromString(decodedRefreshToken.subject))
+        } catch(e: JWTVerificationException) {
+            throw UnauthorizedException(ServiceErrorCode.JWT_VERIFICATION_FAILED.code, "리프레시 토큰이 유효하지 않습니다.")
+        }
+
+        val memberInfo = memberAuthenticationInfoRepository.findById(memberId)
+            ?: throw NotFoundException(ServiceErrorCode.AUTHENTICATION_INFO_NOT_FOUND.code, "회원의 인증 정보가 존재하지 않습니다.")
+        val accessToken = jwtService.createAccessToken(memberId)
+
+        return AuthenticationSuccess(accessToken = accessToken, refreshToken = refreshToken)
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/JWTService.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/JWTService.kt
@@ -1,0 +1,54 @@
+package kr.dohoon_kim.msa.auth_service.service
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import kr.dohoon_kim.msa.auth_service.configs.JwtConfiguration
+import kr.dohoon_kim.msa.auth_service.domain.MemberId
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.Date
+
+@Service
+class JWTService(private val jwtConfiguration: JwtConfiguration) {
+
+    private val accessTokenAlgorithm = Algorithm.HMAC256(jwtConfiguration.accessTokenSecret)
+
+    private val refreshTokenAlgorithm = Algorithm.HMAC256(jwtConfiguration.refreshTokenSecret)
+
+    fun createAccessToken(memberId: MemberId): String {
+        val now = Instant.now()
+        val expiration = now.plusMillis(jwtConfiguration.accessTokenExpiration)
+
+        return JWT.create()
+            .withIssuer(jwtConfiguration.issuer)
+            .withSubject(memberId.id.toString())
+            .withExpiresAt(Date.from(expiration))
+            .sign(accessTokenAlgorithm)
+    }
+
+    fun createRefreshToken(memberId: MemberId): String {
+        val now = Instant.now()
+        val expiration = now.plusMillis(jwtConfiguration.refreshTokenExpiration)
+
+        return JWT.create()
+            .withIssuer(jwtConfiguration.issuer)
+            .withSubject(memberId.id.toString())
+            .withExpiresAt(Date.from(expiration))
+            .sign(refreshTokenAlgorithm)
+    }
+
+    fun verifyAccessToken(token: String): DecodedJWT {
+        return JWT.require(accessTokenAlgorithm)
+            .withIssuer(jwtConfiguration.issuer)
+            .build()
+            .verify(token)
+    }
+
+    fun verifyRefreshToken(token: String): DecodedJWT {
+        return JWT.require(refreshTokenAlgorithm)
+            .withIssuer(jwtConfiguration.issuer)
+            .build()
+            .verify(token)
+    }
+}

--- a/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/dto/AuthenticationSuccess.kt
+++ b/auth-service/src/main/kotlin/kr/dohoon_kim/msa/auth_service/service/dto/AuthenticationSuccess.kt
@@ -1,0 +1,7 @@
+package kr.dohoon_kim.msa.auth_service.service.dto
+
+data class AuthenticationSuccess(
+    val type: String="Bearer",
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/auth-service/src/main/resources/application.yaml
+++ b/auth-service/src/main/resources/application.yaml
@@ -1,0 +1,33 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:auth-db
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  hibernate:
+    ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+  flyway:
+    enabled: true
+    locations: classpath:/db/migration
+    username: sa
+    password:
+
+jwt:
+  issuer: "https://identification.dohoon-kim.kr"
+  access-token:
+    secret: access-token-secret
+    expiration: 600000
+  refresh-token:
+    secret: refresh-token-secret
+    expiration: 86400000
+
+logging:
+  level:
+    root: DEBUG

--- a/auth-service/src/main/resources/db/migration/V0__init_table.sql
+++ b/auth-service/src/main/resources/db/migration/V0__init_table.sql
@@ -1,0 +1,13 @@
+create table if not exists member_authentication_info (
+    id UUID primary key not null,
+    nickname varchar(255) not null,
+    password varchar(255) not null,
+    created_at timestamp not null default now(),
+    last_login_at timestamp default null
+);
+
+insert into member_authentication_info(
+    id, nickname, password, created_at, last_login_at
+) values (
+    '01917f7a-3d9f-75aa-be6b-ef76d583653b', 'admin', '$2b$12$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG', now(), null
+);

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/TestConfig.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/TestConfig.kt
@@ -1,0 +1,8 @@
+package kr.dohoon_kim.msa.auth_service
+
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TestConfig {
+
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAUthenticationInfoTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAUthenticationInfoTest.kt
@@ -1,0 +1,53 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import java.util.*
+
+class MemberAUthenticationInfoTest : AnnotationSpec() {
+
+    @Test
+    fun `생성자를 통한 객체 생성`() {
+        val memberId = MemberId(UUID.randomUUID())
+
+        val member = MemberAuthenticationInfo(
+            id = memberId,
+            nickname = "test",
+            password = "test"
+        )
+
+        member.identifier shouldBe memberId
+        member.nickname shouldBe "test"
+        member.password shouldBe "test"
+    }
+
+    @Test
+    fun `닉네임 변경 테스트`() {
+        val memberId = MemberId(UUID.randomUUID())
+
+        val member = MemberAuthenticationInfo(
+            id = memberId,
+            nickname = "test",
+            password = "test"
+        )
+
+        member.changeNickname("new")
+
+        member.nickname shouldBe "new"
+    }
+
+    @Test
+    fun `비밀번호 변경 테스트`() {
+        val memberId = MemberId(UUID.randomUUID())
+
+        val member = MemberAuthenticationInfo(
+            id = memberId,
+            nickname = "test",
+            password = "test"
+        )
+
+        member.changePassword("new")
+
+        member.password shouldBe "new"
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationRepositoryTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/domain/MemberAuthenticationRepositoryTest.kt
@@ -1,0 +1,79 @@
+package kr.dohoon_kim.msa.auth_service.domain
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.slf4j.LoggerFactory
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.repository.findByIdOrNull
+import java.util.*
+
+@DataJpaTest
+class MemberAuthenticationRepositoryTest(
+    private val memberAuthenticationRepository: MemberAuthenticationInfoRepository
+): AnnotationSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    private lateinit var memberId: MemberId
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @BeforeEach
+    fun setUp() {
+        memberId = MemberId(UUID.randomUUID())
+        val defaultMember = MemberAuthenticationInfo(
+            id = memberId,
+            nickname = "test",
+            password = "test"
+        )
+        memberAuthenticationRepository.save(defaultMember)
+        logger.info("default Member : ${defaultMember.identifier}")
+    }
+
+    @Test
+    fun `사용자 아이디를 통한 조회`() {
+        val member = memberAuthenticationRepository.findByIdOrNull(memberId)
+        member shouldNotBe null
+        member as MemberAuthenticationInfo
+        member.identifier shouldBe memberId
+        member.nickname shouldBe "test"
+        logger.debug("password : ${member.password}")
+        member.password shouldBe "test"
+    }
+
+    @Test
+    fun `인증 정보 엔티티 추가 테스트`() {
+        val newMember = MemberAuthenticationInfo(
+            id = MemberId(UUID.randomUUID()),
+            nickname = "new",
+            password = "new"
+        )
+
+        val savedMember = memberAuthenticationRepository.save(newMember)
+        savedMember shouldNotBe null
+        savedMember.identifier shouldBe newMember.identifier
+        savedMember.nickname shouldBe newMember.nickname
+        savedMember.password shouldBe newMember.password
+    }
+
+    @Test
+    fun `인증 정보 엔티티 수정 테스트`() {
+        val member = memberAuthenticationRepository.findByIdOrNull(memberId)
+        member shouldNotBe null
+        member as MemberAuthenticationInfo
+        member.changeNickname("new")
+        member.changePassword("new")
+        val updatedMember = memberAuthenticationRepository.save(member)
+        updatedMember shouldNotBe null
+        updatedMember.identifier shouldBe memberId
+        updatedMember.nickname shouldBe "new"
+        updatedMember.password shouldBe "new"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        memberAuthenticationRepository.deleteAll()
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/helper/BaseAnnotationSpecUnitTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/helper/BaseAnnotationSpecUnitTest.kt
@@ -1,0 +1,17 @@
+package kr.dohoon_kim.msa.auth_service.helper
+
+import io.kotest.core.spec.style.AnnotationSpec
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+
+abstract class BaseAnnotationSpecUnitTest : AnnotationSpec(){
+
+    protected lateinit var validator: Validator
+
+    @BeforeAll
+    fun setUp() {
+        val factory = Validation.buildDefaultValidatorFactory()
+        validator = factory.validator
+    }
+
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/helper/JwtHelper.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/helper/JwtHelper.kt
@@ -1,0 +1,18 @@
+package kr.dohoon_kim.msa.auth_service.helper
+
+import kr.dohoon_kim.msa.auth_service.configs.JwtConfiguration
+
+class JwtHelper {
+
+    companion object {
+        fun createJwtConfigs(): JwtConfiguration {
+            return JwtConfiguration(
+                issuer = "test",
+                accessTokenSecret = "test",
+                accessTokenExpiration = 60000,
+                refreshTokenSecret = "test",
+                refreshTokenExpiration = 86400000
+            )
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/AuthenticationControllerTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/AuthenticationControllerTest.kt
@@ -1,0 +1,75 @@
+package kr.dohoon_kim.msa.auth_service.interfaces
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.NicknamePasswordLoginRequest
+import kr.dohoon_kim.msa.auth_service.interfaces.dto.RefreshTokenRequest
+import kr.dohoon_kim.msa.auth_service.service.AuthenticationService
+import kr.dohoon_kim.msa.auth_service.service.dto.AuthenticationSuccess
+import kotlin.math.exp
+
+class AuthenticationControllerTest: AnnotationSpec() {
+
+    private val authenticationService = mockk<AuthenticationService>()
+
+    private val authenticationController = AuthenticationController(authenticationService)
+
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @Test
+    fun `닉네임 패스워드 로그인 요청`() {
+        // Given 로그인 요청이 주어진다.
+        val request = NicknamePasswordLoginRequest("nickname", "password")
+        val expected = AuthenticationSuccess(
+            type = "Bearer",
+            accessToken = "accessToken",
+            refreshToken = "refreshToken"
+        )
+
+        // When 로그인이 성공하면
+        every { authenticationService.nicknamePasswordAuthentication(any(), any()) } returns expected
+
+        shouldNotThrowAny {
+            val response = authenticationController.login(request)
+            // Then 인증 응답 객체가 반환된다.
+            response.refreshToken shouldNotBe null
+            response.accessToken shouldNotBe  null
+            response.tokenType shouldBe "Bearer"
+        }
+
+    }
+
+    @Test
+    fun `토큰 재발급 요청`() {
+        //Given
+        val request = RefreshTokenRequest(type = "Bearer", refreshToken = "refreshToken")
+        val expected = AuthenticationSuccess(
+            type = "Bearer",
+            accessToken = "accessToken",
+            refreshToken = "refreshToken"
+        )
+
+        // When
+        every { authenticationService.refreshAccessToken(any()) } returns expected
+
+        //Then
+        shouldNotThrowAny {
+            val response = authenticationController.refresh(request)
+            response.refreshToken shouldNotBe null
+            response.accessToken shouldNotBe null
+            response.tokenType shouldBe "Bearer"
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/NicknamePasswordLoginRequestTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/interfaces/dto/NicknamePasswordLoginRequestTest.kt
@@ -1,0 +1,38 @@
+package kr.dohoon_kim.msa.auth_service.interfaces.dto
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.dohoon_kim.msa.auth_service.helper.BaseAnnotationSpecUnitTest
+
+class NicknamePasswordLoginRequestTest: BaseAnnotationSpecUnitTest() {
+
+    @Test
+    fun `닉네임 패스워드 로그인 요청 객체가 정상인 경우 에러가 발생하지 않는다`() {
+        // Given
+        val request = NicknamePasswordLoginRequest(nickname = "nickname", password = "password")
+        // When
+        val violations = validator.validate(request)
+        // Then
+        violations.size shouldBe 0
+    }
+
+    @Test
+    fun `닉네임이 없는 경우 에러가 발생한다`() {
+        // Given
+        val request = NicknamePasswordLoginRequest(nickname = "", password = "password")
+        // When
+        val violations = validator.validate(request)
+        // Then
+        violations.size shouldBe 1
+    }
+
+    @Test
+    fun `패스워드가 없는 경우 에러가 발생한다`() {
+        // Given
+        val request = NicknamePasswordLoginRequest(nickname = "nickname", password = "")
+        // When
+        val violations = validator.validate(request)
+        // Then
+        violations.size shouldBe 1
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/service/AuthenticationServiceTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/service/AuthenticationServiceTest.kt
@@ -1,0 +1,82 @@
+package kr.dohoon_kim.msa.auth_service.service
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kr.dohoon_kim.lectures.msa.common.responses.errors.NotFoundException
+import kr.dohoon_kim.lectures.msa.common.responses.errors.UnauthorizedException
+import kr.dohoon_kim.msa.auth_service.domain.MemberAuthenticationInfo
+import kr.dohoon_kim.msa.auth_service.domain.MemberAuthenticationInfoRepository
+import kr.dohoon_kim.msa.auth_service.domain.MemberId
+import kr.dohoon_kim.msa.auth_service.helper.JwtHelper
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.util.UUID
+
+class AuthenticationServiceTest: AnnotationSpec() {
+
+    private val memberAuthenticationInfoRepository = mockk<MemberAuthenticationInfoRepository>()
+    private val jwtService = JWTService(JwtHelper.createJwtConfigs())
+    private val passwordEncoder = mockk<PasswordEncoder>()
+    private val authenticationService = AuthenticationService(memberAuthenticationInfoRepository, jwtService, passwordEncoder)
+
+    private val memberId = MemberId(UUID.randomUUID())
+    private val defaultMember = MemberAuthenticationInfo(
+        id = memberId,
+        nickname = "test",
+        password = "test"
+    )
+    private lateinit var refreshToken: String
+
+    @BeforeEach
+    fun setUp() {
+        refreshToken = jwtService.createRefreshToken(memberId)
+    }
+
+    @Test
+    fun `사용자 닉네임과 비밀번호를 통한 인증`() {
+        // given
+        every { memberAuthenticationInfoRepository.findByNickname("test") } returns defaultMember
+        every { passwordEncoder.matches("test", "test") } returns true
+        // when
+        val result = authenticationService.nicknamePasswordAuthentication("test", "test")
+
+        // then
+        result.accessToken shouldNotBe null
+        result.refreshToken shouldNotBe null
+        result.type shouldBe "Bearer"
+
+        shouldNotThrowAny {
+            jwtService.verifyAccessToken(result.accessToken)
+            jwtService.verifyRefreshToken(result.refreshToken)
+        }
+    }
+
+    @Test
+    fun`회원이 존재하지 않는 경우 UnauthorizedException 발생`() {
+        every { memberAuthenticationInfoRepository.findByNickname("test") } returns null
+
+        shouldThrow<UnauthorizedException> {
+            authenticationService.nicknamePasswordAuthentication("test", "test")
+        }
+    }
+
+    @Test
+    fun `회원이 존재하지만 비밀번호가 일치하지 않는 경우 UnauthorizedException 발생`() {
+        every { memberAuthenticationInfoRepository.findByNickname("test") } returns defaultMember
+        every { passwordEncoder.matches(any(), any()) } returns false
+
+        shouldThrow<UnauthorizedException> {
+            authenticationService.nicknamePasswordAuthentication("test", "wrong")
+        }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        clearAllMocks()
+    }
+}

--- a/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/service/JWTServiceTest.kt
+++ b/auth-service/src/test/kotlin/kr/dohoon_kim/msa/auth_service/service/JWTServiceTest.kt
@@ -1,0 +1,79 @@
+package kr.dohoon_kim.msa.auth_service.service
+
+import com.auth0.jwt.exceptions.JWTVerificationException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.dohoon_kim.msa.auth_service.configs.JwtConfiguration
+import kr.dohoon_kim.msa.auth_service.domain.MemberId
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class JWTServiceTest(): AnnotationSpec() {
+
+    private val jwtConfiguration = JwtConfiguration(
+        accessTokenSecret = "accessToken",
+        refreshTokenSecret = "refreshToken",
+        accessTokenExpiration = 600000,
+        refreshTokenExpiration = 86400000,
+        issuer = "issuer"
+    )
+
+    private lateinit var publishedAccessToken: String
+    private lateinit var memberId: MemberId
+    private lateinit var jwtService: JWTService
+
+    @BeforeEach
+    fun setUp() {
+        jwtService = JWTService(jwtConfiguration)
+        memberId = MemberId(UUID.randomUUID())
+        publishedAccessToken = jwtService.createAccessToken(memberId)
+    }
+
+
+    @Test
+    fun `createAccessToken 테스트`() {
+        val memberId = MemberId(UUID.randomUUID())
+        val token = jwtService.createAccessToken(memberId)
+        val decoded = jwtService.verifyAccessToken(token)
+        decoded.subject shouldBe memberId.id.toString()
+    }
+
+    @Test
+    fun `createRefreshToken 테스트`() {
+        val memberId = MemberId(UUID.randomUUID())
+        val token = jwtService.createRefreshToken(memberId)
+        val decoded = jwtService.verifyRefreshToken(token)
+        decoded.subject shouldBe memberId.id.toString()
+    }
+
+    @Test
+    fun `정상 엑세스 토큰 검증`() {
+        val decoded = jwtService.verifyAccessToken(publishedAccessToken)
+        decoded.subject shouldBe memberId.id.toString()
+    }
+
+    @Test
+    fun `변조된 엑세스 토큰 검증 시 에러발생`() {
+        val token = publishedAccessToken.substring(0, publishedAccessToken.length - 1)
+
+        shouldThrow<JWTVerificationException> {
+            jwtService.verifyAccessToken(token)
+        }
+    }
+
+    @Test
+    fun `발급자가 다른 엑세스 토큰 검증 시 에러발생`() {
+        val fakeToken = JWTService(JwtConfiguration(
+            accessTokenSecret = "accessToken",
+            refreshTokenSecret = "refreshToken",
+            accessTokenExpiration = 600000,
+            refreshTokenExpiration = 86400000,
+            issuer = "fake"
+        )).createAccessToken(memberId)
+
+        shouldThrow<JWTVerificationException> {
+            jwtService.verifyAccessToken(fakeToken)
+        }
+    }
+}

--- a/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/MsaCommonConfiguration.kt
+++ b/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/MsaCommonConfiguration.kt
@@ -5,10 +5,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import kr.dohoon_kim.lectures.msa.common.responses.CommonExceptionHandlerAdvice
+import kr.dohoon_kim.lectures.msa.common.responses.DefaultResponseBodyAdvice
 import org.slf4j.LoggerFactory
 
 @AutoConfiguration
-@ConditionalOnProperty(prefix = "msa.auto-configuration", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "kr.dohoon-kim.lectures.msa.auto-configuration", name = ["enabled"], havingValue = "true", matchIfMissing = true)
 class MsaCommonConfiguration {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -18,5 +19,12 @@ class MsaCommonConfiguration {
     fun commonExceptionHandlerAdvice(): CommonExceptionHandlerAdvice {
         logger.info("CommonExceptionHandlerAdvice bean created")
         return CommonExceptionHandlerAdvice()
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "kr.dohoon-kim.lectures.msa.default-response-envelop", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+    fun defaultResponseBodyAdvice(): DefaultResponseBodyAdvice {
+        logger.info("DefaultResponseBodyAdvice bean created")
+        return DefaultResponseBodyAdvice()
     }
 }

--- a/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/ApiResponse.kt
+++ b/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/ApiResponse.kt
@@ -1,10 +1,12 @@
 package kr.dohoon_kim.lectures.msa.common.responses
 
+import org.slf4j.MDC
+
 
 class ApiResponse<T>(
-    val traceId: String? = null,
+    val traceId: String? = MDC.get("traceId") ?: null,
     val status: Int,
-    val data: T?,
+    val payload: T?,
     val message: String = ""
 ) {
 

--- a/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/CommonExceptionHandlerAdvice.kt
+++ b/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/CommonExceptionHandlerAdvice.kt
@@ -91,13 +91,23 @@ open class CommonExceptionHandlerAdvice {
         return makeResponseEntity(e.status, ErrorResponse.Companion.of(e))
     }
 
+    @ExceptionHandler(Exception::class)
+    fun handlerException(e: Exception): ResponseEntity<ApiResponse<ErrorResponse>> {
+        logger.error("Exception occured: ${e.message}")
+        val response = ErrorResponse(
+            code = "INTERNAL_SERVER_ERROR",
+            message = e.message
+        )
+        return makeResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, response)
+    }
+
     private fun makeResponseEntity(status: HttpStatus, errorResponse: ErrorResponse)
     : ResponseEntity<ApiResponse<ErrorResponse>> {
         return ResponseEntity.status(status).body(
             ApiResponse<ErrorResponse>(
                 traceId = MDC.get("traceId")?:null,
                 status = status.value(),
-                data = errorResponse,
+                payload = errorResponse,
                 message = errorResponse.message?:""
             )
         )

--- a/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/DefaultResponseBodyAdvice.kt
+++ b/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/DefaultResponseBodyAdvice.kt
@@ -1,0 +1,37 @@
+package kr.dohoon_kim.lectures.msa.common.responses
+
+import org.slf4j.MDC
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+
+class DefaultResponseBodyAdvice: ResponseBodyAdvice<Any> {
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+
+        val status = returnType.getMethodAnnotation(Envelop::class.java)!!.status
+        val message = returnType.getMethodAnnotation(Envelop::class.java)!!.message
+        response.setStatusCode(status)
+
+        return ApiResponse<Any>(
+            status = status.value(),
+            message = message,
+            payload = body
+        )
+    }
+
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {
+        return returnType.hasMethodAnnotation(Envelop::class.java)
+    }
+}

--- a/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/Envelop.kt
+++ b/common/src/main/kotlin/kr/dohoon_kim/lectures/msa/common/responses/Envelop.kt
@@ -1,0 +1,9 @@
+package kr.dohoon_kim.lectures.msa.common.responses
+
+import org.springframework.http.HttpStatus
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Envelop(val status: HttpStatus, val message: String = "Success") {
+
+}


### PR DESCRIPTION
## 추가된 부분 
### common module 
- DefaultResponseBodyAdvice 추가 - 프리미티브 타입을 제외한 객체에 대해 ApiResponse 객체로 모든 응답을 래핑

### auth-service
- 닉네임 패스워드 로그인 엔드포인트 추가 (/api/v1/auth/nickname-password
- JWT Access token 재발급 엔드포인트 추가 (/api/v1/auth/jwt/refresh-token)